### PR TITLE
Remove c_str usage from error constructor calls

### DIFF
--- a/src/UIPlatform/Menus/MultiLayerMenu.cpp
+++ b/src/UIPlatform/Menus/MultiLayerMenu.cpp
@@ -17,7 +17,7 @@ namespace NL::Menus
         if (FAILED(hResult))
         {
             const auto errorMsg = fmt::format("{}: failed to QueryInterface() with {} and result {}", NameOf(MultiLayerMenu), NameOf(ID3D11Device1), hResult);
-            throw std::runtime_error(errorMsg.c_str());
+            throw std::runtime_error(errorMsg);
         }
 
         ID3D11DeviceContext3* immediateContext = nullptr;

--- a/src/UIPlatform/Services/CEFService.cpp
+++ b/src/UIPlatform/Services/CEFService.cpp
@@ -8,13 +8,13 @@ namespace NL::Services
 
         if (s_cefApp != nullptr)
         {
-            throw std::runtime_error(fmt::format("{}: CEF already inited", NameOf(CEFService)).c_str());
+            throw std::runtime_error(fmt::format("{}: CEF already inited", NameOf(CEFService)));
         }
 
         CefMainArgs args(GetModuleHandleA(nullptr));
         if (!CefInitialize(args, a_cefSettings, a_cefApp, nullptr))
         {
-            throw std::runtime_error(fmt::format("{}: failed to initialize CEF, code {}", NameOf(CEFService), CefGetExitCode()).c_str());
+            throw std::runtime_error(fmt::format("{}: failed to initialize CEF, code {}", NameOf(CEFService), CefGetExitCode()));
         }
 
         s_cefApp = a_cefApp;


### PR DESCRIPTION
A nano fix for consistency and also a nano performance improvement: 

I think std::string can be faster to copy rather than construct from const char*.

1. std::string has size included, no need to re-calculate.
2. std::string has small string optimization.
3. speaking about copying, I think MSVC will even move instead of copy

Happy new year!